### PR TITLE
458 add citation type functionality with backend data

### DIFF
--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -1,10 +1,43 @@
 
 // Citations logic
+
+// citation dropdown functionality
 const citationsDropdown = document.getElementById( 'citations-dropdown' );
 
 citationsDropdown.addEventListener( 'change', ( event ) => {
-    // temp behavior, logging selected type
-    console.log( `Citation type: ${event.target.value}` );
+    const citationType = event.target.value;
+    const articleInfoObj = JSON.parse( localStorage.getItem( 'last-retrieved' ) ?? 'null' );
+  
+    // return here if there is no article info in localstorage
+    if ( !articleInfoObj ) return;
+  
+    // get all card text elements
+    const allCitationCards = document.querySelectorAll( 'span.card-citation-text' );
+    
+    const allCitations = articleInfoObj.citations;
+    allCitationCards.forEach( ( cardTextElement, index ) => {
+        cardTextElement.textContent = formatCitationByType( allCitations[index], citationType );
+    } );
 
-    // TODO: format article information based on selected type
 } );
+
+function formatCitationByType( articleObj, citationFormat ) {
+    const {title, authors, publication, publicationDate } = articleObj;
+
+    switch ( citationFormat ) { // formatting here is weird!
+
+    case 'apa': 
+        return `${authors}. ${publicationDate}. ${title}. ${publication}`;
+
+    case 'mla': 
+        return `${authors}. ${title}. ${publication}, ${publicationDate}`;
+
+    case 'harvard': 
+        return `${authors}, ${publicationDate}. ${title}. ${publication}`;
+
+    case 'chicago': 
+        return `${authors}. ${title}. ${publication}. ${publicationDate}`;
+
+    }
+
+}

--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -31,19 +31,19 @@ citationsDropdown.addEventListener( 'change', ( event ) => {
 function formatCitationByType( articleObj, citationFormat ) {
     const {title, authors, publication, publicationDate } = articleObj;
 
-    switch ( citationFormat ) { // formatting here is weird!
+    switch ( citationFormat ) {
 
     case 'apa': 
-        return `${formatAuthorsByCitationType( authors, 'apa' )}. ${publicationDate}. ${title}. ${publication}`;
+        return `${formatAuthorsByCitationType( authors, 'apa' )} ${publicationDate}. ${title}. ${publication}`;
 
     case 'mla': 
-        return `${formatAuthorsByCitationType( authors, 'mla' )}. ${title}. ${publication}, ${publicationDate}`;
+        return `${formatAuthorsByCitationType( authors, 'mla' )} ${title}. ${publication}, ${publicationDate}`;
 
     case 'harvard': 
         return `${formatAuthorsByCitationType( authors, 'harvard' )}, ${publicationDate}. ${title}. ${publication}`;
 
     case 'chicago': 
-        return `${formatAuthorsByCitationType( authors, 'chicago' )}. ${title}. ${publication}. ${publicationDate}`;
+        return `${formatAuthorsByCitationType( authors, 'chicago' )} ${title}. ${publication}. ${publicationDate}`;
 
     }
 
@@ -111,7 +111,7 @@ function formatAuthorsByCitationType( authors, citationFormat ) {
 
     // add et al if necessary
     if ( needsEtAl ) {
-        return finalAuthorStrings.join( '; ' ) + ' et al';
+        return finalAuthorStrings.join( '; ' ) + ' et al.';
     }
     else {
         return finalAuthorStrings.join( '; ' );

--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -86,7 +86,7 @@ function formatAuthorsByCitationType( authors, citationFormat ) {
             const [ lastName, firstName ] = name;
 
             // MLA is lastName, firstName
-            finalAuthorStrings.push( `${lastName}, ${firstName}` );
+            finalAuthorStrings.push( `${lastName}, ${firstName}.` );
         } );
         break;
 

--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -27,17 +27,98 @@ function formatCitationByType( articleObj, citationFormat ) {
     switch ( citationFormat ) { // formatting here is weird!
 
     case 'apa': 
-        return `${authors}. ${publicationDate}. ${title}. ${publication}`;
+        return `${formatAuthorsByCitationType( authors, 'apa' )}. ${publicationDate}. ${title}. ${publication}`;
 
     case 'mla': 
-        return `${authors}. ${title}. ${publication}, ${publicationDate}`;
+        return `${formatAuthorsByCitationType( authors, 'mla' )}. ${title}. ${publication}, ${publicationDate}`;
 
     case 'harvard': 
-        return `${authors}, ${publicationDate}. ${title}. ${publication}`;
+        return `${formatAuthorsByCitationType( authors, 'harvard' )}, ${publicationDate}. ${title}. ${publication}`;
 
     case 'chicago': 
-        return `${authors}. ${title}. ${publication}. ${publicationDate}`;
+        return `${formatAuthorsByCitationType( authors, 'chicago' )}. ${title}. ${publication}. ${publicationDate}`;
 
     }
 
+}
+
+
+function formatAuthorsByCitationType( authors, citationFormat ) {
+    let needsEtAl = false; // flag to include et al at the end of the authors names 
+    let reducedAuthors = [];
+
+    if ( authors.length > 2 ) { // have to reduce for 3 or more
+        needsEtAl = true;
+
+        reducedAuthors = getFirstNameLastNames( [ authors[0], authors[1], authors[2] ] );
+    }
+    else {
+        reducedAuthors = getFirstNameLastNames( authors );
+    }
+    
+    const finalAuthorStrings = [];
+
+    switch ( citationFormat ) {
+
+    case 'apa':
+        reducedAuthors.forEach( ( name ) => {
+            const [ lastName, firstName ] = name;
+
+            // APA is lastName, firstInitial 
+            finalAuthorStrings.push( `${lastName}, ${firstName.substring( 0, 1 )}.` );
+        } );
+        break;
+    case 'mla':
+        reducedAuthors.forEach( ( name ) => {
+            const [ lastName, firstName ] = name;
+
+            // MLA is lastName, firstName
+            finalAuthorStrings.push( `${lastName}, ${firstName}` );
+        } );
+        break;
+
+    case 'harvard': 
+        reducedAuthors.forEach( ( name ) => {
+            const [ lastName, firstName ] = name;
+
+            // Harvard is lastName, firstInitial 
+            finalAuthorStrings.push( `${lastName}, ${firstName.substring( 0, 1 )}.` );
+        } );
+        break;
+
+    case 'chicago': 
+        reducedAuthors.forEach( ( name ) => {
+            const [ lastName, firstName ] = name;
+
+            // Chicago is lastName, firstName
+            finalAuthorStrings.push( `${lastName}, ${firstName.substring( 0, 1 )}.` );
+        } );
+        break;
+    }
+
+    // add et al if necessary
+    if ( needsEtAl ) {
+        return finalAuthorStrings.join( '; ' ) + ' et al';
+    }
+    else {
+        return finalAuthorStrings.join( '; ' );
+    }
+}
+
+
+function getFirstNameLastNames( authors ) {
+    let names = [];
+
+    authors.forEach( ( authorName ) => {
+        let authorNames = authorName.split( ' ' );
+
+        // last name is at index 1 if there is no middle inital, 2 otherwise
+        let lastName = authorNames.length > 2 ? authorNames[2] : authorNames[1];
+        let firstName = authorNames[0];
+
+        names.push( [ lastName, firstName ] );
+    } );
+
+
+    return names;
 }

--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -21,6 +21,13 @@ citationsDropdown.addEventListener( 'change', ( event ) => {
 
 } );
 
+/**
+ * Formats an article object based on citation format.
+ * 
+ * @param {{title: string, authors: string[], publication: string, publicationDate: string}} articleObj 
+ * @param {'apa' | 'mla' | 'harvard' | 'chicago'} citationFormat 
+ * @returns {string} a formatted citation string for the article
+ */
 function formatCitationByType( articleObj, citationFormat ) {
     const {title, authors, publication, publicationDate } = articleObj;
 
@@ -42,7 +49,13 @@ function formatCitationByType( articleObj, citationFormat ) {
 
 }
 
-
+/**
+ * Formats author names based on citation format
+ * 
+ * @param {string[]} authors 
+ * @param {'apa' | 'mla' | 'harvard' | 'chicago'} citationFormat 
+ * @returns {string} a formatted string of authors name based on citation format
+ */
 function formatAuthorsByCitationType( authors, citationFormat ) {
     let needsEtAl = false; // flag to include et al at the end of the authors names 
     let reducedAuthors = [];
@@ -105,7 +118,12 @@ function formatAuthorsByCitationType( authors, citationFormat ) {
     }
 }
 
-
+/**
+ * Splits an array of author name strings to tuples of [lastName, firstName]
+ * 
+ * @param {string[]} authors 
+ * @returns {string[][]} list of author name tuples
+ */
 function getFirstNameLastNames( authors ) {
     let names = [];
 


### PR DESCRIPTION
Resolves #458 

- Citation drop down now pulls article data from local storage when user switches citation type
- After pulling the article data, it is formatted and inserted into the cards on the modal.



## To test locally
1. Insert article data into local storage with the key being `last-retrieved`
2. Switch between citation types in the drop down

Sample article data:
```json
{
    "citations": [
        {
            "title": "Sample Article A",
            "authors": ["John Doe"],
            "publication": "Article Samples",
            "publicationDate": 2023,
            "link": "https://www.semanticscholar.org/paper/00be12552ede0d2c4b5064f845941d06906a7257",
            "summary": "test article"
        },
        {
            "title": "Sample Article B",
            "authors": [
                "Jane Doe",
                "John Robert",
                "Thomas Bob",
                "Jason Liv"
            ],
            "publication": "Fake Publication",
            "publicationDate": 2020,
            "link": "https://www.semanticscholar.org/paper/6b85b63579a916f705a8e10a49bd8d849d91b1fc",
            "summary": "This is a fake article."
        }
    ]
}
```
