### PR TITLE
X button functionality 

### DIFF
--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -172,12 +172,12 @@ document.querySelectorAll( 'button.card-close-btn' ).forEach( ( xButton ) => {
         // the x-button is nested in two divs, so parent div is three levels up
         const cardID = this.parentElement.parentElement.parentElement.getAttribute( 'data-card-index' );
 
-        deleteCard( cardID );
+        deleteCardFromLocalStorage( cardID );
     } );
 } );
 
 // deletes card from local storage and places it in seperate "removed" field (name can change!)
-function deleteCard( cardID ) {
+function deleteCardFromLocalStorage( cardID ) {
     const localStorageArticleJSON = JSON.parse( localStorage.getItem( 'last-retrieved' ) ?? 'null' );
 
     // exit here if there is no local storage json
@@ -192,7 +192,7 @@ function deleteCard( cardID ) {
             const deletedArticleObj = articleObjs.splice( index, 1 )[0];
 
             // put deleted article in separate local storage field
-            writeDeleted( deletedArticleObj );
+            writeDeletedToLocalStorage( deletedArticleObj );
         }
     } );
 
@@ -201,7 +201,7 @@ function deleteCard( cardID ) {
 }
 
 // add deleted article to local storage
-function writeDeleted( articleObj ) {
+function writeDeletedToLocalStorage( articleObj ) {
     // get local array if it exists, else create new empty array
     const localRemovedArticlesArray = JSON.parse( localStorage.getItem( 'removed' ) ?? '[]' );
 

--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -162,3 +162,16 @@ document.getElementById( 'myPopover' ).addEventListener( 'mouseenter', function 
 document.getElementById( 'myPopover' ).addEventListener( 'mouseleave', function () {
     myPopover.hide();
 } );
+
+
+// X button logic
+
+// get all the x buttons and add the click event listener
+document.querySelectorAll( 'button.card-close-btn' ).forEach( ( xButton ) => {
+    xButton.addEventListener( 'click', function () {
+        // the x-button is nested in two divs, so parent div is three levels up
+        const cardID = this.parentElement.parentElement.parentElement.getAttribute( 'data-card-index' );
+
+        alert( `CARD_ID: ${cardID}` );
+    } );
+} );

--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -195,6 +195,9 @@ function deleteCard( cardID ) {
             writeDeleted( deletedArticleObj );
         }
     } );
+
+    // update localStorageArticleJSON after removal
+    localStorage.setItem( 'last-retrieved', JSON.stringify( localStorageArticleJSON ) );
 }
 
 // add deleted article to local storage

--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -172,6 +172,24 @@ document.querySelectorAll( 'button.card-close-btn' ).forEach( ( xButton ) => {
         // the x-button is nested in two divs, so parent div is three levels up
         const cardID = this.parentElement.parentElement.parentElement.getAttribute( 'data-card-index' );
 
-        alert( `CARD_ID: ${cardID}` );
+        deleteCard( cardID );
     } );
 } );
+
+// deletes card from local storage and places it in seperate _ field 
+function deleteCard( cardID ) {
+    const localStorageArticleJSON = JSON.parse( localStorage.getItem( 'last-retrieved' ) ?? 'null' );
+
+    // exit here if there is no local storage json
+    if ( !localStorageArticleJSON ) return;
+
+    const articleObjs = localStorageArticleJSON.citations;
+
+    // find article with matching index and remove
+    articleObjs.forEach( ( articleObj, index ) => {
+        if ( articleObj.id == cardID ) {
+
+            console.log( articleObj );
+        }
+    } );
+}

--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -176,7 +176,7 @@ document.querySelectorAll( 'button.card-close-btn' ).forEach( ( xButton ) => {
     } );
 } );
 
-// deletes card from local storage and places it in seperate _ field 
+// deletes card from local storage and places it in seperate "removed" field (name can change!)
 function deleteCard( cardID ) {
     const localStorageArticleJSON = JSON.parse( localStorage.getItem( 'last-retrieved' ) ?? 'null' );
 
@@ -188,8 +188,21 @@ function deleteCard( cardID ) {
     // find article with matching index and remove
     articleObjs.forEach( ( articleObj, index ) => {
         if ( articleObj.id == cardID ) {
+            // remove article from citations array
+            const deletedArticleObj = articleObjs.splice( index, 1 )[0];
 
-            console.log( articleObj );
+            // put deleted article in separate local storage field
+            writeDeleted( deletedArticleObj );
         }
     } );
+}
+
+// add deleted article to local storage
+function writeDeleted( articleObj ) {
+    // get local array if it exists, else create new empty array
+    const localRemovedArticlesArray = JSON.parse( localStorage.getItem( 'removed' ) ?? '[]' );
+
+    localRemovedArticlesArray.push( articleObj );
+
+    localStorage.setItem( 'removed', JSON.stringify( localRemovedArticlesArray ) );
 }

--- a/client/agora/public/js/agnesAI.js
+++ b/client/agora/public/js/agnesAI.js
@@ -170,9 +170,11 @@ document.getElementById( 'myPopover' ).addEventListener( 'mouseleave', function 
 document.querySelectorAll( 'button.card-close-btn' ).forEach( ( xButton ) => {
     xButton.addEventListener( 'click', function () {
         // the x-button is nested in two divs, so parent div is three levels up
-        const cardID = this.parentElement.parentElement.parentElement.getAttribute( 'data-card-index' );
-
+        const cardDiv = this.parentElement.parentElement.parentElement;
+        const cardID = cardDiv.getAttribute( 'data-card-index' );
+        
         deleteCardFromLocalStorage( cardID );
+        cardDiv.remove();
     } );
 } );
 


### PR DESCRIPTION
Resolves #470
- The cards X button now removes the article from the local storage citations JSON and add its to a separate list in local storage named `removed` (name can change).
- The x button also removes the card from the DOM after removing it from local storage.

## To test
1. Add the sample article json to local storage under the key `last-retrieved`:
```json
{
   "citations":[
      {
	 "id": "0",
         "title":"Sample Article A",
         "authors":[
            "John Doe"
         ],
         "publication":"Article Samples",
         "publicationDate":2023,
         "link":"https://www.semanticscholar.org/paper/00be12552ede0d2c4b5064f845941d06906a7257",
         "summary":"test article"
      },
      {
	 "id": "1",
         "title":"Sample Article B",
         "authors":[
            "Jane Doe",
            "John Robert",
            "Thomas Bob",
            "Jason Liv"
         ],
         "publication":"Fake Publication",
         "publicationDate":2020,
         "link":"https://www.semanticscholar.org/paper/6b85b63579a916f705a8e10a49bd8d849d91b1fc",
         "summary":"This is a fake article."
      }
   ]
}
```
2. Add this custom data attribute to the cards container div with the class "citation-card": `data-card-index="0"` for the first card and `data-card-index="1"` for the second card.
3. Start up agora and press the x button on any of the cards. You can also look at local storage to see the articles get removed.


## Note
While not yet implemented, this change relies on the fact that the response json returned from fetching includes an `id` field, and the fact that the created cards are going to include the `data-card-index` attribute. In it's current state, it will not work if those aren't included.